### PR TITLE
Update package configuration and add CDN build support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "genui-widget",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Embeddable chat client for webhooks and workflow providers",
-  "main": "./dist/chat.bundle.es.js",
-  "module": "./dist/chat.bundle.es.js",
+  "main": "./dist/genui-widget.umd.js",
+  "module": "./dist/genui-widget.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/chat.bundle.es.js"
+      "import": "./dist/genui-widget.es.js",
+      "require": "./dist/genui-widget.umd.js"
     }
   },
   "files": [

--- a/vite.config.cdn.ts
+++ b/vite.config.cdn.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+// CDN build configuration with React bundled in
+// This creates a standalone UMD bundle for <script> tag usage
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+  build: {
+    // Don't empty dist folder since we're adding to existing builds
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      name: "GenuiWidget",
+      formats: ["umd"], // Only UMD for CDN
+      fileName: () => "genui-widget.cdn.js", // Use .js for browser compatibility
+    },
+    rollupOptions: {
+      // Don't externalize anything - bundle everything including React
+      // This makes it usable directly in browsers via CDN
+      output: {
+        // Disable code splitting for single file output
+        inlineDynamicImports: true,
+      },
+    },
+    minify: "terser",
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,22 +8,28 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, "src/index.ts"),
-      name: "ThesysChat",
-      formats: ["es"],
-      fileName: () => "chat.bundle.es.js",
+      name: "GenuiWidget",
+      formats: ["es", "umd"],
+      fileName: (format) => `genui-widget.${format}.js`,
     },
     rollupOptions: {
       // Externalize peer dependencies
-      external: ["react", "react-dom"],
+      // external: ["react", "react-dom"],
       output: {
-        globals: {
-          react: "React",
-          "react-dom": "ReactDOM",
+        // globals: {
+        //   react: "React",
+        //   "react-dom": "ReactDOM",
+        // },
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name === "style.css") return "genui-widget.css";
+          return assetInfo.name || "assets/[name]-[hash][extname]";
         },
       },
     },
     sourcemap: true,
-    minify: "terser",
+  },
+  define: {
+    "process.env": {},
   },
   server: {
     port: 3000,


### PR DESCRIPTION
- Bump version to 0.2.0 in package.json.
- Change main and module entry points to new UMD and ES module files.
- Introduce vite.config.cdn.ts for CDN build configuration, creating a standalone UMD bundle.
- Update vite.config.ts to support both ES and UMD formats for the library.
